### PR TITLE
Set chroma_sample_position only for YUV 4:2:0

### DIFF
--- a/ravif/src/av1encoder.rs
+++ b/ravif/src/av1encoder.rs
@@ -351,10 +351,10 @@ fn encode_to_av1(p: &Av1EncodeConfig<'_>) -> Result<Vec<u8>, Box<dyn std::error:
         sample_aspect_ratio: Rational::new(1, 1),
         bit_depth,
         chroma_sampling: p.chroma_sampling,
-        chroma_sample_position: if p.chroma_sampling == ChromaSampling::Cs400 {
-            ChromaSamplePosition::Unknown
-        } else {
+        chroma_sample_position: if p.chroma_sampling == ChromaSampling::Cs420 {
             ChromaSamplePosition::Colocated
+        } else {
+            ChromaSamplePosition::Unknown
         },
         pixel_range: p.pixel_range,
         color_description: p.color_description,


### PR DESCRIPTION
The chroma_sample_position syntax element is only used for YUV 4:2:0 in
the AV1 bitstream. So set chroma_sample_position to
ChromaSamplePosition::Unknown for all other YUV formats, including
monochrome (YUV 4:0:0).

Note: For still images, the most common chroma sample position in
practice is the "center" position. Unfortunately the AV1 specification
does not have a value for the "center" chroma sample position. See
https://github.com/AOMediaCodec/av1-avif/issues/88 and
https://github.com/AOMediaCodec/av1-spec/pull/308. This pull request
preserves the ChromaSamplePosition::Colocated value that is currently
used, but it is likely to be incorrect when YUV 4:2:0 is supported.