### PR TITLE
improve WASM compatibility

### DIFF
--- a/ravif/Cargo.toml
+++ b/ravif/Cargo.toml
@@ -22,7 +22,7 @@ rgb = "0.8.29"
 imgref = "1.9.1"
 loop9 = "0.1.3"
 
-[target.'cfg(target_arch = "wasm32")'.dependencies]
+[target.'cfg(target = "wasm32-unknown-unknown")'.dependencies]
 rav1e = { version = "0.5.0", features = ["wasm"] }
 
 [features]


### PR DESCRIPTION
While trying to use `cavif-rs` inside of a project that is compiled to WASM (`wasm32-wasi` to be specific), I encountered two issues. This PR fixes both. I'll add inline-code comments to highlight and explain both issues.

Thanks for making a AVIF image encoder in Rust!

(Some code was just moved, so I'd recommend to hide whitespace changes during review)