### PR TITLE
Add option to use global rayon thread pool

### DIFF
--- a/ravif/src/av1encoder.rs
+++ b/ravif/src/av1encoder.rs
@@ -383,7 +383,7 @@ fn encode_to_av1(p: &Av1EncodeConfig<'_>) -> Result<Vec<u8>, Box<dyn std::error:
     });
 
     if let Some(threads) = p.threads {
-        cfg = cfg.with_threads(p.threads.into());
+        cfg = cfg.with_threads(threads.into());
     }
 
     let mut ctx: Context<u8> = cfg.new_context()?;


### PR DESCRIPTION
When you have multiple optimizations (including other encoders using rayon, like webp or png) using dedicated thread pool causes some locks that cause some locks inside rayon to block all threads except one, this causes that only one cpu core is utilized for whole application.

Because I do not see any way to disable rayon here, other option is to use global thread pool - this scenario seams to also not cause any issues.
