### PR TITLE
Move load_rgba

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,12 +20,12 @@ rgb = "0.8.34"
 cocoa_image = { version = "1.0.5", optional = true }
 imgref = "1.9.4"
 clap = { version = "3.2.22", default-features = false, features = ["color", "suggestions", "wrap_help", "std", "cargo"] }
-load_image = "3.0.1"
+
 
 [features]
 default = ["asm", "static"]
 asm = ["ravif/asm"]
-static = ["load_image/lcms2-static"]
+static = ["ravif/static"]
 
 [profile.dev]
 opt-level = 1

--- a/ravif/Cargo.toml
+++ b/ravif/Cargo.toml
@@ -20,6 +20,7 @@ rgb = "0.8.34"
 imgref = "1.9.4"
 loop9 = "0.1.3"
 quick-error = "2.0.1"
+load_image = "3.0.1"
 
 [target.'cfg(target = "wasm32-unknown-unknown")'.dependencies]
 rav1e = { version = "0.6.3", features = ["wasm"] }
@@ -27,6 +28,7 @@ rav1e = { version = "0.6.3", features = ["wasm"] }
 [features]
 default = ["asm"]
 asm = ["rav1e/asm"]
+static = ["load_image/lcms2-static"]
 
 [profile.release]
 lto = true

--- a/ravif/src/error.rs
+++ b/ravif/src/error.rs
@@ -23,3 +23,5 @@ quick_error! {
         }
     }
 }
+
+pub type BoxError = Box<dyn std::error::Error + Send + Sync>;

--- a/ravif/src/lib.rs
+++ b/ravif/src/lib.rs
@@ -11,11 +11,16 @@
 mod av1encoder;
 
 mod error;
-pub use error::Error;
-pub use av1encoder::ColorSpace;
 pub use av1encoder::AlphaColorMode;
-pub use av1encoder::Encoder;
+pub use av1encoder::ColorSpace;
 pub use av1encoder::EncodedImage;
+pub use av1encoder::Encoder;
+pub use error::BoxError;
+pub use error::Error;
+
+pub mod load_rgba;
+pub use load_rgba::load_rgba;
+
 #[doc(inline)]
 pub use rav1e::prelude::MatrixCoefficients;
 

--- a/ravif/src/load_rgba.rs
+++ b/ravif/src/load_rgba.rs
@@ -1,0 +1,75 @@
+use super::BoxError;
+use super::RGBA8;
+use imgref::ImgVec;
+use load_image::export::rgb::ComponentMap;
+
+#[cfg(not(feature = "cocoa_image"))]
+pub fn load_rgba(data: &[u8], premultiplied_alpha: bool) -> Result<ImgVec<RGBA8>, BoxError> {
+    let img = load_image::load_data(data)?.into_imgvec();
+    let mut img = match img {
+        load_image::export::imgref::ImgVecKind::RGB8(img) => {
+            img.map_buf(|buf| buf.into_iter().map(|px| px.alpha(255)).collect())
+        }
+        load_image::export::imgref::ImgVecKind::RGBA8(img) => img,
+        load_image::export::imgref::ImgVecKind::RGB16(img) => img.map_buf(|buf| {
+            buf.into_iter()
+                .map(|px| px.map(|c| (c >> 8) as u8).alpha(255))
+                .collect()
+        }),
+        load_image::export::imgref::ImgVecKind::RGBA16(img) => img.map_buf(|buf| {
+            buf.into_iter()
+                .map(|px| px.map(|c| (c >> 8) as u8))
+                .collect()
+        }),
+        load_image::export::imgref::ImgVecKind::GRAY8(img) => img.map_buf(|buf| {
+            buf.into_iter()
+                .map(|g| {
+                    let c = g.0;
+                    RGBA8::new(c, c, c, 255)
+                })
+                .collect()
+        }),
+        load_image::export::imgref::ImgVecKind::GRAY16(img) => img.map_buf(|buf| {
+            buf.into_iter()
+                .map(|g| {
+                    let c = (g.0 >> 8) as u8;
+                    RGBA8::new(c, c, c, 255)
+                })
+                .collect()
+        }),
+        load_image::export::imgref::ImgVecKind::GRAYA8(img) => img.map_buf(|buf| {
+            buf.into_iter()
+                .map(|g| {
+                    let c = g.0;
+                    RGBA8::new(c, c, c, g.1)
+                })
+                .collect()
+        }),
+        load_image::export::imgref::ImgVecKind::GRAYA16(img) => img.map_buf(|buf| {
+            buf.into_iter()
+                .map(|g| {
+                    let c = (g.0 >> 8) as u8;
+                    RGBA8::new(c, c, c, (g.1 >> 8) as u8)
+                })
+                .collect()
+        }),
+    };
+
+    if premultiplied_alpha {
+        img.pixels_mut().for_each(|px| {
+            px.r = (u16::from(px.r) * u16::from(px.a) / 255) as u8;
+            px.g = (u16::from(px.g) * u16::from(px.a) / 255) as u8;
+            px.b = (u16::from(px.b) * u16::from(px.a) / 255) as u8;
+        });
+    }
+    Ok(img)
+}
+
+#[cfg(feature = "cocoa_image")]
+pub fn load_rgba(data: &[u8], premultiplied_alpha: bool) -> Result<ImgVec<RGBA8>, BoxError> {
+    if premultiplied_alpha {
+        Ok(cocoa_image::decode_image_as_rgba_premultiplied(data)?)
+    } else {
+        Ok(cocoa_image::decode_image_as_rgba(data)?)
+    }
+}

--- a/tests/stdio.rs
+++ b/tests/stdio.rs
@@ -21,7 +21,7 @@ fn stdio() -> Result<(), std::io::Error> {
     let mut data = Vec::new();
     cmd.stdout.take().unwrap().read_to_end(&mut data)?;
     assert!(cmd.wait()?.success());
-    assert_eq!(&data[4..4+8], b"ftypavif");
+    assert_eq!(&data[4..4 + 8], b"ftypavif");
     Ok(())
 }
 


### PR DESCRIPTION
In order to avoid duplicating the `load_rgba` method (as here for example: https://github.com/kolserdav/ravif-js/blob/master/src/lib.rs#L82) when using `ravif` as a library, it is made public, exported from `ravif`.