### PR TITLE
feat: implement `PartialEq` and `Eq` on `ColorSpace`

### DIFF
--- a/ravif/src/av1encoder.rs
+++ b/ravif/src/av1encoder.rs
@@ -10,7 +10,7 @@ use rgb::RGBA8;
 use crate::rayoff as rayon;
 
 /// For [`Encoder::with_internal_color_space`]
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
 pub enum ColorSpace {
     /// Standard color space for photographic content. Usually the best choice.
     /// This library always uses full-resolution color (4:4:4).


### PR DESCRIPTION
First, thanks for your work on these crates!

I think it makes sense to implement these traits on the ColorSpace enum, considering this a simple enum that does not contain any associated data (in particular no floating-point numbers), and given its name I don't see this changing in the future.