### PR TITLE
Lower MSRV to the crate's actual requirement

### DIFF
--- a/ravif/Cargo.toml
+++ b/ravif/Cargo.toml
@@ -11,7 +11,7 @@ categories = ["multimedia::images", "multimedia::encoding"]
 homepage = "https://lib.rs/ravif"
 repository = "https://github.com/kornelski/cavif-rs"
 include = ["README.md", "LICENSE", "Cargo.toml", "/src/*.rs"]
-rust-version = "1.79" # bitstream-io breaks it
+rust-version = "1.70" # as low as `cargo -Zminimal-versions generate-lockfile` will let us go
 
 [dependencies]
 avif-serialize = "0.8.1"


### PR DESCRIPTION
Instead of listing the highest MSRV any transitive dependency has (which is a moving target and changes behind your back anyway), list the lowest one with which the code can still be compiled.

Actually making use of this lower MSRV requires either Cargo's experimental MSRV-aware resolver or `cargo -Zminimal-versions generate-lockfile`.

This is necessary to ship a new release of the `image` crate, see https://github.com/image-rs/image/pull/2348