### PR TITLE
ravif: Add `#[deprecated]` notice to `ColorSpace`

### DIFF
--- a/ravif/src/av1encoder.rs
+++ b/ravif/src/av1encoder.rs
@@ -12,11 +12,11 @@ use crate::rayoff as rayon;
 /// For [`Encoder::with_internal_color_model`]
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 pub enum ColorModel {
-    /// Standard color space for photographic content. Usually the best choice.
+    /// Standard color model for photographic content. Usually the best choice.
     /// This library always uses full-resolution color (4:4:4).
     /// This library will automatically choose between BT.601 or BT.709.
     YCbCr,
-    /// RGB channels are encoded without colorspace transformation.
+    /// RGB channels are encoded without color space transformation.
     /// Usually results in larger file sizes, and is less compatible than `YCbCr`.
     /// Use only if the content really makes use of RGB, e.g. anaglyph images or RGB subpixel anti-aliasing.
     RGB,
@@ -143,6 +143,7 @@ impl Encoder {
     }
 
     #[doc(hidden)]
+    #[deprecated = "Renamed to `with_internal_color_model()`"]
     pub fn with_internal_color_space(self, color_model: ColorModel) -> Self {
         self.with_internal_color_model(color_model)
     }

--- a/ravif/src/lib.rs
+++ b/ravif/src/lib.rs
@@ -15,6 +15,7 @@ pub use error::Error;
 pub use av1encoder::ColorModel;
 
 #[doc(hidden)]
+#[deprecated = "Renamed to `ColorModel`"]
 pub use ColorModel as ColorSpace;
 
 pub use av1encoder::AlphaColorMode;


### PR DESCRIPTION
Commit e03108a ("Rename color space → model") (for #88) added/kept hidden variants of `ColorSpace` and `with_internal_color_space()` for backwards compatibility, to not need a semver-breaking release. Unfortunately these were not annotated with `#[deprecated]`, making users unaware of this change until they would (if ever) upgrade to the next breaking release of `ravif` where such helpers are supposedly going to be removed again.

Tell users about this with a `#[deprecated]` notice to guide them to the new item names.
