### PR TITLE
Fix conversion bug in `convert_alpha`

### DIFF
--- a/ravif/src/av1encoder.rs
+++ b/ravif/src/av1encoder.rs
@@ -247,8 +247,8 @@ impl Encoder {
                     .filter(|px| px.a != 255)
                     .map(|px| if px.a == 0 { RGBA8::default() } else { RGBA8::new(
                         (u16::from(px.r) * 255 / u16::from(px.a)) as u8,
-                        (u16::from(px.r) * 255 / u16::from(px.a)) as u8,
-                        (u16::from(px.r) * 255 / u16::from(px.a)) as u8,
+                        (u16::from(px.g) * 255 / u16::from(px.a)) as u8,
+                        (u16::from(px.b) * 255 / u16::from(px.a)) as u8,
                         px.a,
                     )})
                     .collect();


### PR DESCRIPTION
The green and blue channels were overridden by the red channel when doing the alpha conversion.
