### PR TITLE
Support encoding 10-bit input data

### DIFF
--- a/ravif/src/av1encoder.rs
+++ b/ravif/src/av1encoder.rs
@@ -235,20 +235,21 @@ impl Encoder {
     }
 
     fn convert_alpha<P: Pixel + Default>(&self, in_buffer: Img<&[Rgba<P>]>) -> Option<ImgVec<Rgba<P>>> {
+        let max_value = (1 << self.depth.to_usize()) -1;
         match self.alpha_color_mode {
             AlphaColorMode::UnassociatedDirty => None,
             AlphaColorMode::UnassociatedClean => blurred_dirty_alpha(in_buffer),
             AlphaColorMode::Premultiplied => {
                 let prem = in_buffer
                     .pixels()
-                    .filter(|px| px.a != P::cast_from(255))
+                    .filter(|px| px.a != P::cast_from(max_value))
                     .map(|px| {
                         if Into::<u32>::into(px.a) == 0 {
                             Rgba::new(px.a, px.a, px.a, px.a)
                         } else {
-                            let r = px.r * P::cast_from(255) / px.a;
-                            let g = px.g * P::cast_from(255) / px.a;
-                            let b = px.b * P::cast_from(255) / px.a;
+                            let r = px.r * P::cast_from(max_value) / px.a;
+                            let g = px.g * P::cast_from(max_value) / px.a;
+                            let b = px.b * P::cast_from(max_value) / px.a;
                             Rgba::new(r, g, b, px.a)
                         }
                     })

--- a/ravif/src/lib.rs
+++ b/ravif/src/lib.rs
@@ -27,7 +27,7 @@ mod dirtyalpha;
 #[doc(no_inline)]
 pub use imgref::Img;
 #[doc(no_inline)]
-pub use rgb::{RGB8, RGBA8};
+pub use rgb::{RGB16, RGB8, RGBA16, RGBA8};
 
 #[cfg(not(feature = "threading"))]
 mod rayoff {


### PR DESCRIPTION
~~⚠️ Depends on #89~~

In the current implementation, 8 or 10-bit signals can be stored, but they are always derived from 8-bit signals, offering no visual improvement. All incoming data has been assumed to be 8-bit sRGB. This PR takes the first step in removing these assumptions by enabling the input of signals with a depth of 10-bits. It lays the groundwork for full support of writing HDR images.